### PR TITLE
Replace bwa.kit with custom script with fixed hs38DH and CHM13 compatibility 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 *.fastq filter=lfs diff=lfs merge=lfs -text
 *.gz filter=lfs diff=lfs merge=lfs -text
+resources/eul1db_SRIP.txt filter=lfs diff=lfs merge=lfs -text
+.test/data/USD07_F1_S92_chr22_R2.fastq.gz filter=lfs diff=lfs merge=lfs -text
+.test/data/USD7_F1_S92.pickle.gz filter=lfs diff=lfs merge=lfs -text
+.test/data/USD07_F1_S92_chr22_R1.fastq.gz filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,8 @@ jobs:
         snakefile: workflow/Snakefile
         args: "--lint"
 
-  Testing:
-    timeout-minutes: 1000
+  Test-Preprocessing:
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     needs:
       - Linting
@@ -44,16 +44,35 @@ jobs:
         lfs: true
     - name: Checkout LFS objects
       run: git lfs checkout
-    - name: Test workflow on single sample
+    - name: Test workflow through flank_features on chr22 data only
+      uses: snakemake/snakemake-github-action@v1.24.0
+      with:
+        directory: .
+        stagein: mamba install -n snakemake -c conda-forge biopython -y -q
+        snakefile: workflow/Snakefile
+        args: "--until results/flank_features/test/mda/chr22.pickle.gz --use-conda --show-failed-logs --cores 4 --conda-cleanup-pkgs cache --all-temp --configfile .test/config_chr22/config.yml"
+
+  Test-Model: 
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    needs:
+      - Linting
+      - Formatting
+    steps: 
+    - uses: actions/checkout@v2
+      with:
+        lfs: true
+    - name: Checkout LFS objects
+      run: git lfs checkout
+    - name: Test workflow after flank_features, using pickle from full
       uses: snakemake/snakemake-github-action@v1.24.0
       with:
         directory: .
         stagein: |
           mamba install -n snakemake -c conda-forge biopython -y -q
-          export SNAKEMAKE_OUTPUT_CACHE=$(pwd)/.snakemake-cache/
-          mkdir -p $SNAKEMAKE_OUTPUT_CACHE
+          mkdir -p results/flank_features/test/mda/ && cp .test/data/USD7_F1_S92.pickle.gz results/flank_features/test/mda/test.pickle.gz
         snakefile: workflow/Snakefile
-        args: "--use-conda --cache --show-failed-logs --cores 4 --conda-cleanup-pkgs cache --all-temp --configfile .test/config_sample/config.yml"
+        args: "--use-conda --show-failed-logs --cores 4 --conda-cleanup-pkgs cache --all-temp --configfile .test/config_model/config.yml"
 
     # - name: Test report
     #   uses: snakemake/snakemake-github-action@v1.24.0

--- a/.test/config_chr22/config.yml
+++ b/.test/config_chr22/config.yml
@@ -1,0 +1,22 @@
+# path or URL to sample sheet (TSV format, columns: donor, sample, dna_type,...)
+samples: .test/config_chr22/test.tsv
+
+genome:
+  build: hs37d5 # options: <hs38DH|hs37d5>
+  region: chr22 # use 22 for hs37d5, use chr22 for hs38DH
+  database: eul1db
+
+# chain file (None if no liftover expected)
+chain: hg19ToHg38.over.chain.gz
+
+adapters:
+  r1_adapter: 'AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCT'
+  r2_adapter: 'CAAGCAGAAGACGGCATACGAGANNNNNNNGTGACTGGAGTTCAGACGTGTGCTCTTCCGATCT'
+  nested_primer: 'TAACTAACCTGCACAATGTGCAC'
+
+model:
+  num_folds: 2
+  min_reads: 3
+  fold_window: 20_000_000
+  window_size: 750
+  prob: 0.7

--- a/.test/config_chr22/test.tsv
+++ b/.test/config_chr22/test.tsv
@@ -1,0 +1,2 @@
+donor	sample	dna_type	R1	R2
+test	chr22	mda	.test/data/USD07_F1_S92_chr22_R1.fastq.gz	.test/data/USD07_F1_S92_chr22_R2.fastq.gz

--- a/.test/config_model/config.yml
+++ b/.test/config_model/config.yml
@@ -1,0 +1,22 @@
+# path or URL to sample sheet (TSV format, columns: donor, sample, dna_type,...)
+samples: .test/config_model/test.tsv
+
+genome:
+  build: hs37d5 # options: <hs38DH|hs37d5>
+  region: all # use 22 for hs37d5, use chr22 for hs38DH
+  database: eul1db
+
+# chain file (None if no liftover expected)
+chain: hg19ToHg38.over.chain.gz
+
+adapters:
+  r1_adapter: 'AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCT'
+  r2_adapter: 'CAAGCAGAAGACGGCATACGAGANNNNNNNGTGACTGGAGTTCAGACGTGTGCTCTTCCGATCT'
+  nested_primer: 'TAACTAACCTGCACAATGTGCAC'
+
+model:
+  num_folds: 4
+  min_reads: 3
+  fold_window: 20_000_000
+  window_size: 750
+  prob: 0.7

--- a/.test/config_model/test.tsv
+++ b/.test/config_model/test.tsv
@@ -1,0 +1,2 @@
+donor	sample	dna_type	R1	R2
+test	test	mda	.test/data/USD07_F1_S92_R1.fastq.gz	.test/data/USD07_F1_S92_R2.fastq.gz

--- a/.test/data/USD07_F1_S92_chr22_R1.fastq.gz
+++ b/.test/data/USD07_F1_S92_chr22_R1.fastq.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:421e61caa33db45e1113c1a206bd2e24332a6f5366cd46b193723f778224068b
+size 2365387

--- a/.test/data/USD07_F1_S92_chr22_R2.fastq.gz
+++ b/.test/data/USD07_F1_S92_chr22_R2.fastq.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc17634ac1c3c4c9c2858cf0493113915e96f633008896ec71ec88959bab46c9
+size 2165154

--- a/.test/data/USD7_F1_S92.pickle.gz
+++ b/.test/data/USD7_F1_S92.pickle.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37cbb0fa2a3c1659508ffaf98d78301750caeb165dcaf9145219e7a4ab0cb679
+size 3305254

--- a/README.md
+++ b/README.md
@@ -13,11 +13,42 @@ snakefmt .
 # run lint checks
 snakemake --lint
 
-# Test
+# Testing
 # NOTE: Tests do not work from within tmux environment
 # Set cachedir
 export SNAKEMAKE_OUTPUT_CACHE=$(pwd)/.snakemake-cache
 mkdir -p $SNAKEMAKE_OUTPUT_CACHE
-# Run test
-snakemake --cores 1 all --configfile .test/config_sample/config.yml --cache --rerun-incomplete --show-failed-logs --use-conda --debug
+
+# Quick test on steps through feature extraction
+snakemake \
+   --configfile .test/config_chr22/config.yml \
+   --until results/flank_features/test/mda/chr22.pickle.gz \
+   --cores 4 \
+   --use-conda \
+   --show-failed-logs \
+   --conda-cleanup-pkgs cache \
+   --all-temp \
+   --cache
+
+# Quick test on steps following feature extraction
+snakemake \
+   --configfile .test/config_model/config.yml \
+   all \
+   --cores 4 \
+   --use-conda \
+   --show-failed-logs \
+   --conda-cleanup-pkgs cache \
+   --all-temp \
+   --cache
+
+# Test the pipeline all the way through
+snakemake \
+   --configfile .test/config_sample/config.yml \
+    all \
+   --cores 4 \
+   --use-conda \
+   --show-failed-logs \
+   --conda-cleanup-pkgs cache \
+   --all-temp \
+   --cache
 ```

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -1,8 +1,10 @@
 rule bwa_index:
     input:
-        rules.fix_names_clean.output.fa,
+        f"resources/{{ref}}/{ref_basename}.fa"
     output:
-        idx=multiext("resources/{ref}/genome", ".amb", ".ann", ".bwt", ".pac", ".sa"),
+        idx=multiext(
+            f"resources/{{ref}}/{ref_basename}", ".amb", ".ann", ".bwt", ".pac", ".sa"
+        ),
     log:
         "resources/{ref}/bwa_index.log",
     cache: True
@@ -13,7 +15,10 @@ rule bwa_index:
 rule bwa_mem:
     input:
         reads=[rules.cutadapt2.output.fastq1, rules.cutadapt2.output.fastq2],
-        idx=expand(rules.bwa_index.output.idx, ref=config["ref"]["build"]),
+        idx=expand(
+            rules.bwa_index.output.idx,
+            ref=config["ref"]["build"]
+        ),
     output:
         "results/bwa_mem/{donor}/{dna_type}/{sample}.bam",
     log:
@@ -64,7 +69,10 @@ rule install_gapafim:
 rule tags:
     input:
         bam=rules.rmdup.output,
-        fa=expand(rules.fix_names_clean.output.fa, ref=config["ref"]["build"]),
+        fa=expand(
+            f"resources/{{ref}}/{ref_basename}.fa",
+            ref=config["ref"]["build"]
+        ),
         gapafim=rules.install_gapafim.output,
     output:
         "results/tags/{donor}/{dna_type}/{sample}.bam",

--- a/workflow/rules/align.smk
+++ b/workflow/rules/align.smk
@@ -1,6 +1,6 @@
 rule bwa_index:
     input:
-        f"resources/{{ref}}/{ref_basename}.fa"
+        f"resources/{{ref}}/{ref_basename}.fa",
     output:
         idx=multiext(
             f"resources/{{ref}}/{ref_basename}", ".amb", ".ann", ".bwt", ".pac", ".sa"
@@ -15,10 +15,7 @@ rule bwa_index:
 rule bwa_mem:
     input:
         reads=[rules.cutadapt2.output.fastq1, rules.cutadapt2.output.fastq2],
-        idx=expand(
-            rules.bwa_index.output.idx,
-            ref=config["ref"]["build"]
-        ),
+        idx=expand(rules.bwa_index.output.idx, ref=config["ref"]["build"]),
     output:
         "results/bwa_mem/{donor}/{dna_type}/{sample}.bam",
     log:
@@ -69,10 +66,7 @@ rule install_gapafim:
 rule tags:
     input:
         bam=rules.rmdup.output,
-        fa=expand(
-            f"resources/{{ref}}/{ref_basename}.fa",
-            ref=config["ref"]["build"]
-        ),
+        fa=expand(f"resources/{{ref}}/{ref_basename}.fa", ref=config["ref"]["build"]),
         gapafim=rules.install_gapafim.output,
     output:
         "results/tags/{donor}/{dna_type}/{sample}.bam",

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -29,6 +29,7 @@ def get_cutadapt_input(wildcards):
             read=[1, 2],
         )
 
+
 # handle conditional alterations to reference genome
 ref = config["ref"]["build"]
 gen_ref_basename = "genome"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -29,6 +29,20 @@ def get_cutadapt_input(wildcards):
             read=[1, 2],
         )
 
+# handle conditional alterations to reference genome
+ref = config["ref"]["build"]
+gen_ref_basename = "genome"
+
+# handle trimming for a region
+region = config["ref"]["region"]
+if region != "all":
+    gen_ref_basename = f"genome_{region}"
+
+# handle fixing chr names
+if "hs37" in ref:
+    ref_basename = f"{gen_ref_basename}_hg19names"
+else:
+    ref_basename = gen_ref_basename
 
 # setup input/output for folds rule
 def get_folds_input_samples(wildcards):

--- a/workflow/rules/model.smk
+++ b/workflow/rules/model.smk
@@ -2,9 +2,13 @@ rule features:
     input:
         bgz=rules.tabix.output.bgz,
         tbi=rules.tabix.output.tbi,
-        fa=expand(rules.fix_names_clean.output.fa, ref=config["ref"]["build"]),
+        fa=expand(
+            f"resources/{{ref}}/{ref_basename}.fa",
+            ref=config["ref"]["build"]
+        ),
         chromsizes=expand(
-            rules.fix_names_clean.output.chromsizes, ref=config["ref"]["build"]
+            f"resources/{{ref}}/{ref_basename}.genome",
+            ref=config["ref"]["build"]
         ),
     output:
         bgz="results/features/{donor}/{dna_type}/{sample}.bgz",
@@ -49,7 +53,8 @@ rule flank_features:
         bgz=rules.features.output.bgz,
         tbi=rules.features.output.tbi,
         chromsizes=expand(
-            rules.fix_names_clean.output.chromsizes, ref=config["ref"]["build"]
+            f"resources/{{ref}}/{ref_basename}.genome",
+            ref=config["ref"]["build"]
         ),
     output:
         "results/flank_features/{donor}/{dna_type}/{sample}.pickle.gz",
@@ -65,10 +70,14 @@ rule folds:
     input:
         samples=get_folds_input_samples,
         chromsizes=expand(
-            rules.fix_names_clean.output.chromsizes, ref=config["ref"]["build"]
+            f"resources/{{ref}}/{ref_basename}.genome",
+            ref=config["ref"]["build"]
         ),
         non_ref_l1=get_non_ref_l1,
-        ref_l1=expand(rules.get_rmsk.output.ref_l1, ref=config["ref"]["build"]),
+        ref_l1=expand(
+            rules.get_rmsk.output.ref_l1,
+            ref=config["ref"]["build"]
+        ),
     params:
         # non_ref_db=config["ref"]["database"]
         num_folds=config["model"]["num_folds"],

--- a/workflow/rules/model.smk
+++ b/workflow/rules/model.smk
@@ -2,13 +2,9 @@ rule features:
     input:
         bgz=rules.tabix.output.bgz,
         tbi=rules.tabix.output.tbi,
-        fa=expand(
-            f"resources/{{ref}}/{ref_basename}.fa",
-            ref=config["ref"]["build"]
-        ),
+        fa=expand(f"resources/{{ref}}/{ref_basename}.fa", ref=config["ref"]["build"]),
         chromsizes=expand(
-            f"resources/{{ref}}/{ref_basename}.genome",
-            ref=config["ref"]["build"]
+            f"resources/{{ref}}/{ref_basename}.genome", ref=config["ref"]["build"]
         ),
     output:
         bgz="results/features/{donor}/{dna_type}/{sample}.bgz",
@@ -53,8 +49,7 @@ rule flank_features:
         bgz=rules.features.output.bgz,
         tbi=rules.features.output.tbi,
         chromsizes=expand(
-            f"resources/{{ref}}/{ref_basename}.genome",
-            ref=config["ref"]["build"]
+            f"resources/{{ref}}/{ref_basename}.genome", ref=config["ref"]["build"]
         ),
     output:
         "results/flank_features/{donor}/{dna_type}/{sample}.pickle.gz",
@@ -70,14 +65,10 @@ rule folds:
     input:
         samples=get_folds_input_samples,
         chromsizes=expand(
-            f"resources/{{ref}}/{ref_basename}.genome",
-            ref=config["ref"]["build"]
+            f"resources/{{ref}}/{ref_basename}.genome", ref=config["ref"]["build"]
         ),
         non_ref_l1=get_non_ref_l1,
-        ref_l1=expand(
-            rules.get_rmsk.output.ref_l1,
-            ref=config["ref"]["build"]
-        ),
+        ref_l1=expand(rules.get_rmsk.output.ref_l1, ref=config["ref"]["build"]),
     params:
         # non_ref_db=config["ref"]["database"]
         num_folds=config["model"]["num_folds"],

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -1,40 +1,34 @@
-rule install_bwakit:
-    output:
-        directory("resources/bwa.kit"),
-    conda:
-        "../envs/env.yml"
-    log:
-        "resources/install_bwakit.log",
-    shell:
-        """
-        mkdir -p resources && cd resources
-        wget -O- -q --no-config https://sourceforge.net/projects/bio-bwa/files/bwakit/bwakit-0.7.15_x64-linux.tar.bz2 | tar xfj -
-        """
-
-
 rule gen_ref:
-    input:
-        rules.install_bwakit.output,
     output:
-        "resources/{ref}/genome_og.fa",
+        f"resources/{{ref}}/{gen_ref_basename}.fa"
     log:
         "resources/{ref}/gen_ref.log",
     conda:
         "../envs/env.yml"
     params:
-        region=config["ref"]["region"],
+        region = config["ref"]["region"]
     cache: True
     shell:
         """
-        touch {log} && exec 1>{log} 2>&1
+        # start logging
+        touch {log} && exec 2>{log} 
 
-        # run bwa.kit function
-        {input}/run-gen-ref {wildcards.ref}
+        # create temp dir, and clean up on exit
+        TMP=$(mktemp -d)
+	    trap 'rm -rf -- "$TMP"' EXIT
+
+        # run the script in the temp dir
+	    cd $TMP
+        set +e # allow errors temporarily to handle broken pipe with hs37d5
+        bash $OLDPWD/workflow/scripts/run-gen-ref.sh {wildcards.ref}
+        set -e
+
+        # filter for the region if specified
+        cd $OLDPWD
         if [ {params.region} != "all" ]; then
-            samtools faidx {wildcards.ref}.fa {params.region} > {output}
-            rm -f {wildcards.ref}.fa*
+            samtools faidx $TMP/{wildcards.ref}.fa {params.region} > {output}
         else
-            mv {wildcards.ref}.fa {output}
+            mv $TMP/{wildcards.ref}.fa {output}
         fi
         """
 
@@ -44,9 +38,9 @@ rule fix_names_clean:
     input:
         fa=rules.gen_ref.output,
     output:
-        fa="resources/{ref}/genome.fa",
-        fai="resources/{ref}/genome.fa.fai",
-        chromsizes="resources/{ref}/genome.genome",
+        fa=f"resources/{{ref}}/{gen_ref_basename}_hg19names.fa",
+        fai=f"resources/{{ref}}/{gen_ref_basename}_hg19names.fa.fai",
+        chromsizes=f"resources/{{ref}}/{gen_ref_basename}_hg19names.genome",
     log:
         "resources/{ref}/fix_names.log",
     conda:
@@ -57,7 +51,10 @@ rule fix_names_clean:
 
 rule get_eul1db:
     input:
-        genome=expand("resources/{ref}/genome.genome", ref=config["ref"]["build"]),
+        genome=expand(
+            f"resources/{{ref}}/{ref_basename}.genome",
+            ref=config["ref"]["build"]
+        ),
         eul1db="resources/eul1db_SRIP.txt",
     output:
         "resources/eul1db/windows.csv",
@@ -71,7 +68,7 @@ rule get_eul1db:
 
 rule get_rmsk:
     input:
-        "resources/{ref}/genome.genome",
+        f"resources/{{ref}}/{ref_basename}.genome",
     output:
         rmsk="resources/{ref}/rmsk.txt.gz",
         ref_l1="resources/{ref}/reference_l1.csv",

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -1,12 +1,12 @@
 rule gen_ref:
     output:
-        f"resources/{{ref}}/{gen_ref_basename}.fa"
+        f"resources/{{ref}}/{gen_ref_basename}.fa",
     log:
         "resources/{ref}/gen_ref.log",
     conda:
         "../envs/env.yml"
     params:
-        region = config["ref"]["region"]
+        region=config["ref"]["region"],
     cache: True
     shell:
         """
@@ -15,10 +15,10 @@ rule gen_ref:
 
         # create temp dir, and clean up on exit
         TMP=$(mktemp -d)
-	    trap 'rm -rf -- "$TMP"' EXIT
+        trap 'rm -rf -- "$TMP"' EXIT
 
         # run the script in the temp dir
-	    cd $TMP
+        cd $TMP
         set +e # allow errors temporarily to handle broken pipe with hs37d5
         bash $OLDPWD/workflow/scripts/run-gen-ref.sh {wildcards.ref}
         set -e
@@ -52,8 +52,7 @@ rule fix_names_clean:
 rule get_eul1db:
     input:
         genome=expand(
-            f"resources/{{ref}}/{ref_basename}.genome",
-            ref=config["ref"]["build"]
+            f"resources/{{ref}}/{ref_basename}.genome", ref=config["ref"]["build"]
         ),
         eul1db="resources/eul1db_SRIP.txt",
     output:

--- a/workflow/scripts/fix_names.py
+++ b/workflow/scripts/fix_names.py
@@ -4,15 +4,14 @@ __author__ = 'Michael Cuoco'
 from Bio import SeqIO
 import pandas as pd
 import pysam
-import os
-import logging
+import sys, gc, traceback
 import snakemake as sm
+import logging 
 
-logging.basicConfig(filename=snakemake.log[0], level=logging.INFO)
+def main():
 
-if "37" in snakemake.wildcards.ref:
+	logging.basicConfig(filename=snakemake.log[0], level=logging.INFO)
 	# read in the chromosome map
-	# TODO: make this a parameter specified in snakemake
 	chrom_map = pd.read_csv("resources/hs37d5_map.tsv", sep="\t", header=None)
 
 	# save filenames to objects
@@ -33,9 +32,21 @@ if "37" in snakemake.wildcards.ref:
 
 			# write the record to the output file
 			SeqIO.write(record, corrected, 'fasta')
-else:
-	os.rename(snakemake.input.fa[0], snakemake.output.fa)
 
-# samtools faidx
-pysam.faidx(snakemake.output.fa)
-sm.shell("cut -f 1,2 {snakemake.output.fai} > {snakemake.output.chromsizes}")
+
+	# samtools faidx
+	pysam.faidx(snakemake.output.fa)
+	sm.shell("cut -f 1,2 {snakemake.output.fai} > {snakemake.output.chromsizes}")
+
+if __name__ == '__main__':
+    try:
+        main()
+
+    except:  # catch *all* exceptions
+        sys.stderr = open(snakemake.log[0], 'w')
+        traceback.print_exc()
+        sys.stderr.close()
+
+    finally:
+        # cleanup code in here
+        gc.collect()

--- a/workflow/scripts/run-gen-ref.sh
+++ b/workflow/scripts/run-gen-ref.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Download the reference genome and decompress 
+# Usage: bash run-gen-ref.sh <chm13v2|hs38|hs38a|hs38DH|hs37|hs37d5>
+# TODO: find bwa indices and download them
+
+# store urls for downloads, 13v2 and 38 are from NCBI GenBank
+url13v2="ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/009/914/755/GCA_009914755.4_T2T-CHM13v2.0/GCA_009914755.4_T2T-CHM13v2.0_genomic.fna.gz"
+# url38="ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_full_analysis_set.fna.gz"
+url38="ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.29_GRCh38.p14/GCA_000001405.29_GRCh38.p14_genomic.fna.gz"
+url37d5="ftp://ftp.ncbi.nlm.nih.gov/1000genomes/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz"
+urlbwakit="https://sourceforge.net/projects/bio-bwa/files/bwakit/bwakit-0.7.15_x64-linux.tar.bz2"
+
+if [ $# -eq 0 ]; then
+	echo "Usage: $0 <chm13v2|hs38|hs38a|hs38DH|hs37|hs37d5>"
+	echo "Analysis sets:"
+	echo "  chm13v2  complete genome from CHM13htert cell line"
+	echo "  hs38     primary assembly of GRCh38 (incl. chromosomes, unplaced and unlocalized contigs) and EBV"
+	echo "  hs38a    hs38 plus ALT contigs"
+	echo "  hs38DH   hs38a plus decoy contigs and HLA genes (recommended for GRCh38 mapping)"
+	echo "  hs37     primary assembly of GRCh37 (used by 1000g phase 1) plus the EBV genome"
+	echo "  hs37d5   hs37 plus decoy contigs (used by 1000g phase 3)"
+	echo ""
+	exit 1;
+fi
+
+# if download hs38, make temp dir and download bwa.kit
+if [[ "$1" == *"hs38"* ]]; then
+	tmp=$(mktemp -d)
+	cd $tmp
+	trap 'rm -rf -- "$tmp"' EXIT
+
+	wget -O- $urlbwakit | tar xfj -
+	cd -
+fi
+
+if [ $1 == "chm13v2" ]; then
+	wget -O- $url13v2 | gzip -dc > $1.fa 2> /dev/null
+elif [ $1 == "hs38DH" ]; then
+	(wget -O- $url38 | gzip -dc; cat $tmp/bwa.kit/resource-GRCh38/hs38DH-extra.fa) > $1.fa 
+	# [ ! -f $1.fa.alt ] && cp $tmp/bwa.kit/resource-GRCh38/hs38DH.fa.alt $1.fa.alt
+elif [ $1 == "hs38a" ]; then
+	wget -O- $url38 | gzip -dc > $1.fa
+	# [ ! -f $1.fa.alt ] && grep _alt $tmp/bwa.kit/resource-GRCh38/hs38DH.fa.alt > $1.fa.alt
+elif [ $1 == "hs38" ]; then
+	wget -O- $url38 | gzip -dc | awk '/^>/{f=/_alt/?0:1}f' > $1.fa
+elif [ $1 == "hs37d5" ]; then
+	wget -O- $url37d5 | gzip -dc > $1.fa 2>/dev/null
+elif [ $1 == "hs37" ]; then
+	wget -O- $url37d5 | gzip -dc 2>/dev/null | awk '/^>/{f=/>hs37d5/?0:1}f' > $1.fa
+else
+	echo "ERROR: unknown genome build"
+fi
+


### PR DESCRIPTION
1. Make `fix_names` conditional. Acheived by storing reference genome basename in variable, conditional on config parameters
2. Split testing preprocess and model to speed up workflow